### PR TITLE
Fix JavaScript error "Uncaught TypeError" when menu is disabled in perspective

### DIFF
--- a/public/js/startup.js
+++ b/public/js/startup.js
@@ -12,15 +12,16 @@ pimcore.bundle.fileexplorer.startup = Class.create({
         this.toolbar = pimcore.globalmanager.get('layout_toolbar');
         const systemInfoMenuItems = this.getSystemInfoMenu();
 
-        const filteredMenu = menu.extras.items.filter(function (item) {
-            return item.itemId === 'pimcore_menu_extras_system_info';
-        });
-
-        const systemInfoMenu = filteredMenu.shift();
-        systemInfoMenuItems.map(function(item) {
-            systemInfoMenu.menu.items.push(item);
-        });
-
+        if (menu.extras) {
+            const filteredMenu = menu.extras.items.filter(function (item) {
+                return item.itemId === 'pimcore_menu_extras_system_info';
+            });
+    
+            const systemInfoMenu = filteredMenu.shift();
+            systemInfoMenuItems.map(function(item) {
+                systemInfoMenu.menu.items.push(item);
+            });
+        }
     },
 
     getSystemInfoMenu: function () {


### PR DESCRIPTION
This PR fixes issue https://github.com/pimcore/file-explorer-bundle/issues/23 by checking existence of `menu.extras` before using it. It will not be available in case the extras menu is disabled in perspective configuration

It's the replacement for PR https://github.com/pimcore/file-explorer-bundle/pull/24 as rebase from 1.x to 1.0 branch was not possible without side effects