### PR TITLE
Migrate to reusable PHP-CS-Fixer workflow

### DIFF
--- a/.github/workflows/new-php-cs-fixer.yaml
+++ b/.github/workflows/new-php-cs-fixer.yaml
@@ -1,27 +1,22 @@
 name: "PHP-CS-Fixer"
 
 on:
-    pull_request:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "*_actions"
-            - "feature-*"
+  pull_request:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "feature-*"
+  push:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "*_actions"
+      - "feature-*"
 
 permissions:
-    contents: read
+  contents: write
 
 jobs:
-    php-cs-fixer:
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
-        with:
-            head_ref: ${{ github.head_ref || github.ref_name }}
-            repository: ${{ github.repository }}
-        secrets:
-            PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}
-
+  php-cs-fixer:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+    secrets: inherit

--- a/.github/workflows/new-php-cs-fixer.yaml
+++ b/.github/workflows/new-php-cs-fixer.yaml
@@ -1,0 +1,27 @@
+name: "PHP-CS-Fixer"
+
+on:
+    pull_request:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+            - "feature-*"
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+            - "*_actions"
+            - "feature-*"
+
+permissions:
+    contents: read
+
+jobs:
+    php-cs-fixer:
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+        with:
+            head_ref: ${{ github.head_ref || github.ref_name }}
+            repository: ${{ github.repository }}
+        secrets:
+            PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}
+

--- a/.github/workflows/new-php-cs-fixer.yaml
+++ b/.github/workflows/new-php-cs-fixer.yaml
@@ -19,4 +19,8 @@ permissions:
 jobs:
   php-cs-fixer:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
-    secrets: inherit
+    with:
+      head_ref: ${{ github.head_ref || github.ref_name }}
+      repository: ${{ github.repository }}
+    secrets:
+      PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}

--- a/.github/workflows/php-cs-fixer.yaml.bak
+++ b/.github/workflows/php-cs-fixer.yaml.bak
@@ -1,0 +1,28 @@
+
+name: PHP-CS-Fixer
+
+on:
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+
+permissions:
+    contents: read
+
+jobs:
+    php-cs-fixer:
+        permissions:
+            contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    ref: ${{ github.head_ref }}
+
+            -   name: PHP-CS-Fixer
+                uses: docker://oskarstark/php-cs-fixer-ga:latest
+
+            -   uses: stefanzweifel/git-auto-commit-action@v4
+                with:
+                    commit_message: Apply php-cs-fixer changes


### PR DESCRIPTION
Automated migration to reusable PHP-CS-Fixer workflow on branch `phpcs_actions`.