### PR TITLE
Reusable workflow

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -17,12 +17,16 @@ env:
     PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
     PRIVATE_REPO: ${{ github.event.repository.private }}
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     setup-matrix:
         runs-on: ubuntu-latest
         outputs:
             php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
+            phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
             private_repo: ${{ env.PRIVATE_REPO }}
         steps:
             - name: Checkout code
@@ -41,55 +45,36 @@ jobs:
                   if [ -f composer.json ]; then
                     php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
                     if [ -z "$php_versions" ]; then
-                      echo "No PHP versions found in composer.json"
-                      echo "Setting default PHP value"
-                      echo "php_versions=default" >> $GITHUB_OUTPUT
+                      echo "php_versions=default" >> "$GITHUB_OUTPUT"
                     else
-                      echo "php_versions=$php_versions" >> $GITHUB_OUTPUT
-                      echo "#### php versions #### : $php_versions"
+                      echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
                     fi
                   else
-                    echo "composer.json not found"
                     exit 1
                   fi
 
-            - name: Set up matrix
+            - name: Set up matrix JSON
               id: set-matrix
               run: |
                   php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
-                  
                   MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-                  
-                  IFS=',' read -ra VERSIONS_ARRAY <<< "$php_versions"
-                  
-                  FILTERED_MATRIX_JSON=$(echo $MATRIX_JSON | jq --arg php_versions "$php_versions" '
-                  {
-                    matrix: [
-                      .configs[] |
-                      select(.php_version == $php_versions) |
-                      .matrix[]
-                    ]
-                  }')
-                  
-                  ENCODED_MATRIX_JSON=$(echo $FILTERED_MATRIX_JSON | jq -c .)
-                  
-                  echo "matrix=${ENCODED_MATRIX_JSON}" >> $GITHUB_OUTPUT
+                  FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+                  ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
+                  echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
     static-analysis:
         needs: setup-matrix
-        strategy:
-            matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-centralized.yaml@main
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
         with:
+            phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
+            private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
             APP_ENV: test
             PIMCORE_TEST: 1
-            PRIVATE_REPO: ${{ needs.setup-matrix.outputs.private_repo}}
-            PHP_VERSION: ${{ matrix.matrix.php-version }}
-            SYMFONY: ${{ matrix.matrix.symfony }}
-            DEPENDENCIES: ${{ matrix.matrix.dependencies }}
-            EXPERIMENTAL: ${{ matrix.matrix.experimental }}
-            PIMCORE_VERSION: ${{ matrix.matrix.pimcore_version }}
-            COMPOSER_OPTIONS: ${{ matrix.matrix.composer_options }}
+            REQUIRE_ADMIN_BUNDLE: "true"
+            COVERAGE: "none"
         secrets:
             SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
             COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+            PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+            PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+            PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}


### PR DESCRIPTION
This pull request updates the static analysis GitHub Actions workflow to improve matrix handling and workflow execution. The main changes focus on how PHP version matrices are parsed and passed to the reusable workflow, as well as updating the workflow to use a unified static analysis workflow file. Additional secrets and options have also been added for improved CI configuration.

**Workflow matrix and execution improvements:**

- Updated the matrix setup to output `phpstan_matrix` instead of the previous `matrix`, and changed the filtering logic to better handle PHP version selection and matrix inclusion (`.github/workflows/static-analysis.yaml`). [[1]](diffhunk://#diff-5d68f6ca696b457d708e1895ce1dcab8820f9d6d9357b3876176cbcdd9808b98R20-R29) [[2]](diffhunk://#diff-5d68f6ca696b457d708e1895ce1dcab8820f9d6d9357b3876176cbcdd9808b98L44-R80)
- Switched the static analysis job to use the `reusable-static-analysis-unified.yaml` workflow instead of the older `reusable-static-analysis-centralized.yaml`, and updated the inputs to match the new matrix structure (`.github/workflows/static-analysis.yaml`).

**Concurrency and CI configuration:**

- Added a concurrency group to the workflow to prevent overlapping runs for the same branch or PR, ensuring that only the latest run is active (`.github/workflows/static-analysis.yaml`).
- Included new secrets and environment variables for enhanced CI instance identification and configuration (`.github/workflows/static-analysis.yaml`).
- Set additional static analysis options such as `REQUIRE_ADMIN_BUNDLE` and `COVERAGE` to further control analysis behavior (`.github/workflows/static-analysis.yaml`).