### PR TITLE
Sync non-matrix workflows with 2.2 (#1305)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,34 +1,14 @@
-name: "CLA Assistant"
+name: CLA check
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 jobs:
-  CLAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: cla-assistant/github-action@v2.1.1-beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/pimcore/pimcore/blob/master/CLA.md' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          allowlist: user1,bot*
-
-         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
-          remote-organization-name: 'pimcore' #enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: 'cla'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+  cla-workflow:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yaml@main
+    if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+    secrets:
+      CLA_ACTION_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}

--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,28 +1,23 @@
-
-name: PHP-CS-Fixer
+name: "PHP-CS-Fixer"
 
 on:
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
+  workflow_dispatch:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "*_actions"
+      - "feature-*"
 
 permissions:
-    contents: read
+  contents: write
 
 jobs:
-    php-cs-fixer:
-        permissions:
-            contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v2
-                with:
-                    ref: ${{ github.head_ref }}
-
-            -   name: PHP-CS-Fixer
-                uses: docker://oskarstark/php-cs-fixer-ga:latest
-
-            -   uses: stefanzweifel/git-auto-commit-action@v4
-                with:
-                    commit_message: Apply php-cs-fixer changes
+  php-style:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+    with:
+      head_ref: ${{ github.head_ref || github.ref_name }}
+      repository: ${{ github.repository }}
+      config_file: ".php-cs-fixer.dist.php"
+    secrets:
+      PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}


### PR DESCRIPTION
Part of product-management#1305, Wave 3 (2024.4 / LTS branches). Same recipe as the previous waves. Reference branch: `2.2`. Every adopted file is byte-identical to it. Codeception / static-analysis workflows untouched (matrix class).

Changes:` adopt:cla.yml adopt:php-cs-fixer.yaml`

**PCL line — no forward-merge will follow** (cross-license boundary: changes travel by cherry-pick only, and PCL lines are separate release tracks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)